### PR TITLE
Added support for Linux x64 builds

### DIFF
--- a/AFSPacker/AFSPacker.csproj
+++ b/AFSPacker/AFSPacker.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <TargetFramework>net6.0</TargetFramework>
+    <RuntimeIdentifiers>win10-x64;linux-x64</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
     <Version>2.1.1</Version>


### PR DESCRIPTION
To be able to build the tool in Ubuntu 22.04, some changes were made:

 - Updated target framework from .NET Core 3.1 to .NET 6
 - Added support for Linux-x64 runtimes

